### PR TITLE
Normalize line endings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,15 @@
     "browserslist-ga",
     "browserslist-stats.json"
   ],
+  "scripts": {
+    "prepublishOnly": "crlf --set=LF index.js"
+  },
   "dependencies": {
     "browserslist-ga": "0.0.12",
     "csvtojson": "^1.1.12",
     "yargs": "^11.0.0"
+  },
+  "devDependencies": {
+    "crlf": "^1.1.1"
   }
 }


### PR DESCRIPTION
Currently on unix machines this package cannot be used because it fails with
```
$ node_modules/.bin/browserslist-ga-export --ignoreRows 0 --reportPath browserslist-stats.csv --outputPath browserslist-stats.json
/usr/bin/env: ‘node\r’: No such file or directory
```

it seems the released file is with windows line endings. I added a `.gitattributes` file that should make sure it is checked out correctly before releasing.

Can you then please try releasing a patch with this again?