### PR TITLE
fix: Upgrade yargs to fix security issue and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 package-lock.json
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "dependencies": {
     "browserslist-ga": "0.0.12",
-    "csvtojson": "^1.1.12",
-    "glob": "^7.1.6",
-    "yargs": "^11.0.0"
+    "csvtojson": "^2.0.10",
+    "fast-glob": "^3.2.4",
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "crlf": "^1.1.1"


### PR DESCRIPTION
- update yargs because of https://www.npmjs.com/advisories/1500
- Use yargs itself to validate args instead of custom code. Gives nice `--help` and nice errors.
- replace glob with fast-glob which has promise support and should be faster
- update csvtojson to version 2 which now also has promise support and is 8-10x faster (according to changelog)
- change error handling slightly 
  - error if no reports were found.
  - global catch clause to catch all errors that might happen
  - above removes the need to have try-catch

Fixes #10 ?