### PR TITLE
fix: Only append ".0" to browser version number if required

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const convertFileRows = (rows) => rows
      * Add trailing decimal point and 0 to browser version number string,
      * otherwise getSubVersion in parse method will not work as expected
      */
-    if (i === headers.indexOf('browserVersion')) {
+    if (i === headers.indexOf('browserVersion') && value.indexOf('.') === -1) {
       value = `${value}.0`;
     }
 


### PR DESCRIPTION
Hi There,

I've just noticed when importing data from GA, it's missing the `Samsung Internet` browser data.

Sample data from the GA CSV export:
```
Android,9,Samsung Internet,9.0,mobile,999
Linux,x86_64,Samsung Internet,16.2,desktop,999
Tizen,5.5,Samsung Internet,3.0,mobile,999
```


Looking under the hood, there's a `.0` value appended in the [convertFileRows method](https://github.com/browserslist/browserslist-ga-export/blob/master/index.js#L77-L83) in order for the `getSubVersion` parser to work for certain browsers.

However, this breaks the parsing of `Samsung Internet` browsers as it uses the [getVersionMatch parser method](https://github.com/browserslist/browserslist-ga/blob/master/src/caniuse-parser.js#L64-L70).
If we append a `.0` to the version, we don't get a version match as `isNaN(versionString)` fails.

To fix this, I've added a rudimental `.` string check - hopefully that's enough!

Thanks!
